### PR TITLE
Pre-install opentofu openstack provider

### DIFF
--- a/execution-environment/execution-environment.yml
+++ b/execution-environment/execution-environment.yml
@@ -20,6 +20,10 @@ dependencies:
 options:
   package_manager_path: /usr/bin/microdnf
 
+additional_build_files:
+  - src: main.tf
+    dest: tofu_setup
+
 additional_build_steps:
   prepend_base:
     # Give the user with UID 1000 a name
@@ -43,7 +47,7 @@ additional_build_steps:
           mv tofu /usr/local/bin && \
           mkdir -p /home/runner/tofu_setup && \
           mkdir -p $TF_PLUGIN_CACHE_DIR
-        COPY main.tf /home/runner/tofu_setup/main.tf
+        COPY _build/tofu_setup/main.tf /home/runner/tofu_setup/main.tf
         RUN cd /home/runner/tofu_setup && terraform init
   prepend_builder:
     - RUN $PYCMD -m pip install -U pip

--- a/execution-environment/execution-environment.yml
+++ b/execution-environment/execution-environment.yml
@@ -42,8 +42,8 @@ additional_build_steps:
     - |
         ENV TF_PLUGIN_CACHE_DIR=/home/runner/.terraform.d/plugin-cache
         ARG opentofu_version=1.6.0
-        RUN wget https://github.com/opentofu/opentofu/releases/download/v{terraform_version}/tofu_${terraform_version}_linux_amd64.zip && \
-          unzip tofu_${terraform_version}_linux_amd64.zip && rm tofu_${terraform_version}_linux_amd64.zip && \
+        RUN wget https://github.com/opentofu/opentofu/releases/download/v${opentofu_version}/tofu_${opentofu_version}_linux_amd64.zip && \
+          unzip tofu_${opentofu_version}_linux_amd64.zip && rm tofu_${opentofu_version}_linux_amd64.zip && \
           mv tofu /usr/local/bin && \
           mkdir -p /home/runner/tofu_setup && \
           mkdir -p $TF_PLUGIN_CACHE_DIR

--- a/execution-environment/execution-environment.yml
+++ b/execution-environment/execution-environment.yml
@@ -40,13 +40,16 @@ additional_build_steps:
           --uid 1000 \
           runner
     - |
-        ENV TF_PLUGIN_CACHE_DIR=/home/runner/.terraform.d/plugin-cache
         ARG opentofu_version=1.6.0
         RUN wget https://github.com/opentofu/opentofu/releases/download/v${opentofu_version}/tofu_${opentofu_version}_linux_amd64.zip && \
           unzip tofu_${opentofu_version}_linux_amd64.zip && rm tofu_${opentofu_version}_linux_amd64.zip && \
-          mv tofu /usr/local/bin && \
-          mkdir -p /home/runner/tofu_setup && \
-          mkdir -p $TF_PLUGIN_CACHE_DIR
+          mv tofu /usr/local/bin
+
+  # add these at the end, so we run in the correct user context
+  append_base:
+    - |
+        ENV TF_PLUGIN_CACHE_DIR=/home/runner/.terraform.d/plugin-cache
+        RUN mkdir -p $TF_PLUGIN_CACHE_DIR && mkdir -p /home/runner/tofu_setup
         COPY _build/tofu_setup/main.tf /home/runner/tofu_setup/main.tf
         RUN cd /home/runner/tofu_setup && tofu init
   prepend_builder:

--- a/execution-environment/execution-environment.yml
+++ b/execution-environment/execution-environment.yml
@@ -48,7 +48,7 @@ additional_build_steps:
           mkdir -p /home/runner/tofu_setup && \
           mkdir -p $TF_PLUGIN_CACHE_DIR
         COPY _build/tofu_setup/main.tf /home/runner/tofu_setup/main.tf
-        RUN cd /home/runner/tofu_setup && terraform init
+        RUN cd /home/runner/tofu_setup && tofu init
   prepend_builder:
     - RUN $PYCMD -m pip install -U pip
     # We don't want these in the final container - only the builder

--- a/execution-environment/execution-environment.yml
+++ b/execution-environment/execution-environment.yml
@@ -23,7 +23,8 @@ options:
 additional_build_steps:
   prepend_base:
     # Give the user with UID 1000 a name
-    - RUN microdnf install shadow-utils -y
+    # wget to pull terraform
+    - RUN microdnf install shadow-utils wget unzip -y
     - |
         RUN groupadd --gid 1000 runner && \
         useradd \
@@ -34,6 +35,16 @@ additional_build_steps:
           --shell /sbin/nologin \
           --uid 1000 \
           runner
+    - |
+        ENV TF_PLUGIN_CACHE_DIR=/home/runner/.terraform.d/plugin-cache
+        ARG opentofu_version=1.6.0
+        RUN wget https://github.com/opentofu/opentofu/releases/download/v{terraform_version}/tofu_${terraform_version}_linux_amd64.zip && \
+          unzip tofu_${terraform_version}_linux_amd64.zip && rm tofu_${terraform_version}_linux_amd64.zip && \
+          mv tofu /usr/local/bin && \
+          mkdir -p /home/runner/tofu_setup && \
+          mkdir -p $TF_PLUGIN_CACHE_DIR
+        COPY main.tf /home/runner/tofu_setup/main.tf
+        RUN cd /home/runner/tofu_setup && terraform init
   prepend_builder:
     - RUN $PYCMD -m pip install -U pip
     # We don't want these in the final container - only the builder

--- a/execution-environment/execution-environment.yml
+++ b/execution-environment/execution-environment.yml
@@ -46,7 +46,7 @@ additional_build_steps:
           mv tofu /usr/local/bin
 
   # add these at the end, so we run in the correct user context
-  append_base:
+  append_final:
     - |
         ENV TF_PLUGIN_CACHE_DIR=/home/runner/.terraform.d/plugin-cache
         RUN mkdir -p $TF_PLUGIN_CACHE_DIR && mkdir -p /home/runner/tofu_setup

--- a/execution-environment/main.tf
+++ b/execution-environment/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 0.14"
+
+  # We need the OpenStack provider
+  required_providers {
+    openstack = {
+      source = "terraform-provider-openstack/openstack"
+      version = "<3.0.0"
+    }
+  }
+}


### PR DESCRIPTION
When v3.0.0 of the openstack provider was release,
the support for the legacy floating ip association resource
has been removed, breaking the deletion of existing appliances.