### PR TITLE
Change lease check interval

### DIFF
--- a/azimuth_caas_operator/tests/utils/test_lease.py
+++ b/azimuth_caas_operator/tests/utils/test_lease.py
@@ -1,8 +1,9 @@
 import unittest
 from unittest import mock
 
-import kopf
 from easykube.rest.util import PropertyDict
+
+import kopf
 
 from azimuth_caas_operator.models.v1alpha1 import cluster as cluster_crd
 from azimuth_caas_operator.utils import lease

--- a/azimuth_caas_operator/tests/utils/test_lease.py
+++ b/azimuth_caas_operator/tests/utils/test_lease.py
@@ -1,9 +1,8 @@
 import unittest
 from unittest import mock
 
-from easykube.rest.util import PropertyDict
-
 import kopf
+from easykube.rest.util import PropertyDict
 
 from azimuth_caas_operator.models.v1alpha1 import cluster as cluster_crd
 from azimuth_caas_operator.utils import lease
@@ -40,7 +39,7 @@ class TestLease(unittest.IsolatedAsyncioTestCase):
             "Lease test1 is not active.",
             str(ctx.exception),
         )
-        self.assertEqual(60, ctx.exception.delay)
+        self.assertEqual(10, ctx.exception.delay)
 
         mock_adopt_lease.assert_awaited_once_with(client, cluster)
 

--- a/azimuth_caas_operator/utils/lease.py
+++ b/azimuth_caas_operator/utils/lease.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 
 import easykube
 import kopf

--- a/azimuth_caas_operator/utils/lease.py
+++ b/azimuth_caas_operator/utils/lease.py
@@ -1,9 +1,9 @@
 import datetime
+import easykube
+import kopf
 import logging
 import os
 
-import easykube
-import kopf
 
 from azimuth_caas_operator.models.v1alpha1 import cluster as cluster_crd
 

--- a/azimuth_caas_operator/utils/lease.py
+++ b/azimuth_caas_operator/utils/lease.py
@@ -119,7 +119,7 @@ async def ensure_lease_active(client, cluster: cluster_crd.Cluster):
         raise LeaseInError(lease_status.get("errorMessage", "Error creating lease"))
 
     LOG.info(f"Lease {cluster.spec.leaseName} is not active, wait till active.")
-    delay = 60
+    delay = int(os.environ.get("LEASE_CHECK_INTERVAL_SECONDS", "10"))
     if lease:
         lease_start_str = lease["spec"].get("startTime")
         if lease_start_str:
@@ -129,7 +129,7 @@ async def ensure_lease_active(client, cluster: cluster_crd.Cluster):
             time_until_expiry = lease_start - datetime.datetime.now(
                 tz=datetime.timezone.utc
             )
-            if time_until_expiry.total_seconds() > 60:
+            if time_until_expiry.total_seconds() > delay:
                 delay = time_until_expiry.total_seconds()
 
     # Wait until the lease is active

--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -51,6 +51,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: LEASE_CHECK_INTERVAL_SECONDS
+              value: {{ .Values.config.leaseCheckIntervalSeconds | quote }}
           ports:
             - name: metrics
               containerPort: 8080

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -8,6 +8,7 @@ config:
   ansibleRunnerImage:
     repository: ghcr.io/azimuth-cloud/azimuth-caas-operator-ee
     tag: ""  # Defaults to appVersion
+  leaseCheckIntervalSeconds: 10
   # Any global extravars to use
   globalExtraVars: {}
 


### PR DESCRIPTION
Amend lease check interval to 10 s from 60 s. Additionally, add `leaseCheckIntervalSeconds` as configurable parameter in Helm chart

Testing to be completed