### PR TITLE
.github/dependabot.yml: Remove GitHub actions from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@
 version: 2
 
 updates:
-  # Automatically propose PRs for out-of-date GitHub actions
+  # Using dependabot for all GHA violates pinning policy
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -16,6 +16,10 @@ updates:
     labels:
       - automation
       - gha-update
+    # Only allow updates for actions maintained by GitHub
+    allow:
+      - dependency-name: "actions/*"
+      - dependency-name: "github-actions/*"
 
   # Automatically propose PRs for Python dependencies
   - package-ecosystem: pip

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Run manifest snapshot test
         run: |
-          docker run -i --rm --user $(id -u) \
+          docker run -i --rm \
             -v $(pwd):/apps \
             helmunittest/helm-unittest \
             charts/operator


### PR DESCRIPTION
We pin our GitHub actions to specific versions so dependabot should not be checking them.