### PR TITLE
ci: split PR workflow to fix pull_request_target secret exposure

### DIFF
--- a/.github/workflows/pr-internal.yaml
+++ b/.github/workflows/pr-internal.yaml
@@ -46,6 +46,8 @@ jobs:
       ref: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
 
+  # The integration tests require the charts, and are only worth running once
+  # the functional tests are passing
   integration_tests:
     needs: [publish_charts, functional_tests]
     uses: ./.github/workflows/integration.yaml

--- a/.github/workflows/pr-internal.yaml
+++ b/.github/workflows/pr-internal.yaml
@@ -1,4 +1,4 @@
-name: on pull request
+name: PR publish (internal only)
 
 on:
   pull_request_target:
@@ -15,26 +15,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Run the unit tests on every PR, even from external repos
-  unit_tests:
-    uses: ./.github/workflows/tox.yaml
-    with:
-      ref: ${{ github.event.pull_request.head.sha }}
-
-  # Run the chart linting on every PR, even from external repos
-  lint:
-    uses: ./.github/workflows/helm-lint.yaml
-    with:
-      ref: ${{ github.event.pull_request.head.sha }}
-  
-  # When the PR is from a branch of the main repo, publish images and charts
+  # Only run for PRs from branches of this repository (not external forks)
+  # to prevent untrusted code from accessing repository secrets via pull_request_target.
   publish_images:
-    needs: [unit_tests, lint]
+    if: github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/publish-images.yaml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
-    if: github.repository == 'azimuth-cloud/azimuth-caas-operator'
     permissions:
       contents: read
       id-token: write         # needed for signing the images with GitHub OIDC Token
@@ -47,27 +35,20 @@ jobs:
     with:
       ref: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
-    if: github.repository == 'azimuth-cloud/azimuth-caas-operator'
     permissions:
       contents: write
       pull-requests: write
 
-  # The functional tests require the runner image, so we can only run them
-  # once the image has been built, and on PRs from the main repo
   functional_tests:
     needs: [publish_images]
     uses: ./.github/workflows/functional.yaml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
     secrets: inherit
-    if: github.repository == 'azimuth-cloud/azimuth-caas-operator'
 
-  # The integration tests require the charts, and are only worth running once
-  # the functional tests are passing
   integration_tests:
     needs: [publish_charts, functional_tests]
     uses: ./.github/workflows/integration.yaml
     with:
       chart-version: ${{ needs.publish_charts.outputs.chart-version }}
     secrets: inherit
-    if: github.repository == 'azimuth-cloud/azimuth-caas-operator'

--- a/.github/workflows/pr-public.yaml
+++ b/.github/workflows/pr-public.yaml
@@ -1,0 +1,26 @@
+name: PR checks (public)
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+      - reopened
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit_tests:
+    uses: ./.github/workflows/tox.yaml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+
+  lint:
+    uses: ./.github/workflows/helm-lint.yaml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
The previous `pr.yaml` used `pull_request_target` for all jobs, including unit tests and lint that require no secrets. `pull_request_target` runs in the context of the base repository and has access to all repository secrets, even for PRs from forks.

Additionally, the only guard was `github.repository == 'azimuth-cloud/azimuth-caas-operator'`, which prevents fork-triggered jobs from running but does not protect against a compromised upstream action ref (@master) exfiltrating secrets during the privileged run.

Changes:
- Add `pr-public.yaml`: uses pull_request (no secrets) to run unit tests and lint for every PR, including those from external forks.
- Add `pr-internal.yaml`: keeps pull_request_target only for jobs that genuinely need repository secrets (image/chart publishing, functional and integration tests). The guard is tightened from `github.repository == '...'` to `github.event.pull_request.head.repo.full_name == github.repository` to explicitly restrict execution to internal branches. Downstream jobs cascade the skip automatically via `needs`.
- Remove `pr.yaml`: replaced by the two files above.