### PR TITLE
ci: pin azimuth-cloud action refs to SHA

### DIFF
--- a/.github/workflows/functional.yaml
+++ b/.github/workflows/functional.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Get SemVer version for current commit
         id: semver
-        uses: azimuth-cloud/github-actions/semver@master
+        uses: azimuth-cloud/github-actions/semver@718c40d2def4fd8acd4bc5fb348bc8a5e6361b31 # master 2026-06-15
 
       - name: Run test
         timeout-minutes: 10

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # Check out the configuration repository
       - name: Set up Azimuth environment
-        uses: azimuth-cloud/azimuth-config/.github/actions/setup@devel
+        uses: azimuth-cloud/azimuth-config/.github/actions/setup@b3b49851b7ddaf9c984e9bdffaee6e26d779d994 # devel 2026-06-18
         with:
           os-clouds: ${{ secrets.OS_CLOUDS }}
           environment-prefix: caas-ci
@@ -39,13 +39,13 @@ jobs:
 
       # Provision Azimuth using the azimuth-ops version under test
       - name: Provision Azimuth
-        uses: azimuth-cloud/azimuth-config/.github/actions/provision@devel
+        uses: azimuth-cloud/azimuth-config/.github/actions/provision@b3b49851b7ddaf9c984e9bdffaee6e26d779d994 # devel 2026-06-18
 
       # # Run the tests
       - name: Run Azimuth tests
-        uses: azimuth-cloud/azimuth-config/.github/actions/test@devel
+        uses: azimuth-cloud/azimuth-config/.github/actions/test@b3b49851b7ddaf9c984e9bdffaee6e26d779d994 # devel 2026-06-18
 
       # Tear down the environment
       - name: Destroy Azimuth
-        uses: azimuth-cloud/azimuth-config/.github/actions/destroy@devel
+        uses: azimuth-cloud/azimuth-config/.github/actions/destroy@b3b49851b7ddaf9c984e9bdffaee6e26d779d994 # devel 2026-06-18
         if: ${{ always() }}

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -32,10 +32,10 @@ jobs:
 
       - name: Get SemVer version for current commit
         id: semver
-        uses: azimuth-cloud/github-actions/semver@master
+        uses: azimuth-cloud/github-actions/semver@718c40d2def4fd8acd4bc5fb348bc8a5e6361b31 # master 2026-06-15
 
       - name: Publish Helm charts
-        uses: azimuth-cloud/github-actions/helm-publish@master
+        uses: azimuth-cloud/github-actions/helm-publish@718c40d2def4fd8acd4bc5fb348bc8a5e6361b31 # master 2026-06-15
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ steps.semver.outputs.version }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Get SemVer version for current commit
         id: semver
-        uses: azimuth-cloud/github-actions/semver@master
+        uses: azimuth-cloud/github-actions/semver@718c40d2def4fd8acd4bc5fb348bc8a5e6361b31 # master 2026-06-15
 
       - name: Calculate metadata for image
         id: image-meta
@@ -47,7 +47,7 @@ jobs:
             type=raw,value=${{ steps.semver.outputs.short-sha }}
 
       - name: Build and push image
-        uses: azimuth-cloud/github-actions/docker-multiarch-build-push@master
+        uses: azimuth-cloud/github-actions/docker-multiarch-build-push@718c40d2def4fd8acd4bc5fb348bc8a5e6361b31 # master 2026-06-15
         with:
           cache-key: azimuth-caas-operator
           context: .
@@ -90,7 +90,7 @@ jobs:
 
       - name: Get SemVer version for current commit
         id: semver
-        uses: azimuth-cloud/github-actions/semver@master
+        uses: azimuth-cloud/github-actions/semver@718c40d2def4fd8acd4bc5fb348bc8a5e6361b31 # master 2026-06-15
 
       - name: Calculate metadata for image
         id: image-meta
@@ -104,7 +104,7 @@ jobs:
             type=raw,value=${{ steps.semver.outputs.short-sha }}
 
       - name: Build and push image
-        uses: azimuth-cloud/github-actions/docker-multiarch-build-push@master
+        uses: azimuth-cloud/github-actions/docker-multiarch-build-push@718c40d2def4fd8acd4bc5fb348bc8a5e6361b31 # master 2026-06-15
         with:
           cache-key: azimuth-caas-operator-ee
           context: ./ee-context/
@@ -133,7 +133,7 @@ jobs:
 
       - name: Get SemVer version for current commit
         id: semver
-        uses: azimuth-cloud/github-actions/semver@master
+        uses: azimuth-cloud/github-actions/semver@718c40d2def4fd8acd4bc5fb348bc8a5e6361b31 # master 2026-06-15
 
       - name: Mirror ARA image
         run: |-


### PR DESCRIPTION
All uses of `azimuth-cloud/github-actions@master` and `azimuth-cloud/azimuth-config@devel` are replaced with their current commit SHA. A compromised or silently updated push to either upstream repository would otherwise immediately affect all pipelines, some of which carry packages: `write`, `id-token: write`, and `OS_CLOUDS`.

- `azimuth-cloud/github-actions  718c40d  # master 2026-06-15`
- `azimuth-cloud/azimuth-config  b3b4985  # devel  2026-06-18`

Files updated: publish-images.yaml, publish-charts.yaml, functional.yaml, integration.yaml.

Reminder: rotate the `OS_CLOUDS` secret after this change is merged.