### PR TITLE
fix: restrict CRD verbs to operator-owned resources only

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -3,8 +3,11 @@ name: azimuth-caas-operator
 description: Helm chart for deploying the Azimuth Cluster-as-a-Service operator.
 type: application
 # The version and appVersion are set by the CI script
-version: 0.1.1
+version: 0.1.0
 appVersion: "main"
+maintainers:
+  - name: azimuth-cloud
+    url: https://github.com/azimuth-cloud
 
 dependencies:
   - name: ara

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -3,7 +3,7 @@ name: azimuth-caas-operator
 description: Helm chart for deploying the Azimuth Cluster-as-a-Service operator.
 type: application
 # The version and appVersion are set by the CI script
-version: 0.1.0
+version: 0.1.1
 appVersion: "main"
 
 dependencies:

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -3,7 +3,7 @@ name: azimuth-caas-operator
 description: Helm chart for deploying the Azimuth Cluster-as-a-Service operator.
 type: application
 # The version and appVersion are set by the CI script
-version: 0.1.0
+version: 0.1.1
 appVersion: "main"
 maintainers:
   - name: azimuth-cloud

--- a/charts/operator/templates/clusterrole-operator.yaml
+++ b/charts/operator/templates/clusterrole-operator.yaml
@@ -4,10 +4,17 @@ metadata:
   name: {{ include "azimuth-caas-operator.fullname" . }}:controller
   labels: {{ include "azimuth-caas-operator.labels" . | nindent 4 }}
 rules:
-  # Required by kopf
+  # Required by kopf — list/watch cannot be scoped with resourceNames (collection ops)
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
-    verbs: ["*"]
+    verbs: ["list", "watch"]
+  # Write access restricted to the CRDs this operator owns
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    resourceNames:
+      - clusters.caas.azimuth.stackhpc.com
+      - clustertypes.caas.azimuth.stackhpc.com
+    verbs: ["get", "create", "update", "patch"]
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["list", "watch"]

--- a/charts/operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -8,7 +8,7 @@ templated manifests should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azimuth-caas-operator
         app.kubernetes.io/version: main
-        helm.sh/chart: azimuth-caas-operator-0.1.0
+        helm.sh/chart: azimuth-caas-operator-0.1.1
         rbac.authorization.k8s.io/aggregate-to-admin: "true"
         rbac.authorization.k8s.io/aggregate-to-edit: "true"
         rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -29,7 +29,7 @@ templated manifests should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azimuth-caas-operator
         app.kubernetes.io/version: main
-        helm.sh/chart: azimuth-caas-operator-0.1.0
+        helm.sh/chart: azimuth-caas-operator-0.1.1
       name: release-name-azimuth-caas-operator:controller
     rules:
       - apiGroups:
@@ -134,7 +134,7 @@ templated manifests should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azimuth-caas-operator
         app.kubernetes.io/version: main
-        helm.sh/chart: azimuth-caas-operator-0.1.0
+        helm.sh/chart: azimuth-caas-operator-0.1.1
       name: release-name-azimuth-caas-operator:tfstate
     rules:
       - apiGroups:
@@ -163,7 +163,7 @@ templated manifests should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azimuth-caas-operator
         app.kubernetes.io/version: main
-        helm.sh/chart: azimuth-caas-operator-0.1.0
+        helm.sh/chart: azimuth-caas-operator-0.1.1
         rbac.authorization.k8s.io/aggregate-to-view: "true"
       name: release-name-azimuth-caas-operator:view
     rules:
@@ -184,7 +184,7 @@ templated manifests should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azimuth-caas-operator
         app.kubernetes.io/version: main
-        helm.sh/chart: azimuth-caas-operator-0.1.0
+        helm.sh/chart: azimuth-caas-operator-0.1.1
       name: release-name-azimuth-caas-operator
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -203,7 +203,7 @@ templated manifests should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azimuth-caas-operator
         app.kubernetes.io/version: main
-        helm.sh/chart: azimuth-caas-operator-0.1.0
+        helm.sh/chart: azimuth-caas-operator-0.1.1
       name: release-name-azimuth-caas-operator
     spec:
       replicas: 1
@@ -269,7 +269,7 @@ templated manifests should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azimuth-caas-operator
         app.kubernetes.io/version: main
-        helm.sh/chart: azimuth-caas-operator-0.1.0
+        helm.sh/chart: azimuth-caas-operator-0.1.1
       name: release-name-azimuth-caas-operator-extravars
     stringData:
       extravars: |
@@ -283,7 +283,7 @@ templated manifests should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azimuth-caas-operator
         app.kubernetes.io/version: main
-        helm.sh/chart: azimuth-caas-operator-0.1.0
+        helm.sh/chart: azimuth-caas-operator-0.1.1
       name: release-name-azimuth-caas-operator
     spec:
       ports:
@@ -304,5 +304,5 @@ templated manifests should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: azimuth-caas-operator
         app.kubernetes.io/version: main
-        helm.sh/chart: azimuth-caas-operator-0.1.0
+        helm.sh/chart: azimuth-caas-operator-0.1.1
       name: release-name-azimuth-caas-operator

--- a/charts/operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,118 +1,5 @@
 templated manifests should match snapshot:
   1: |
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      labels:
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: ara
-        app.kubernetes.io/version: main
-        helm.sh/chart: ara-0.1.0
-      name: release-name-ara
-    spec:
-      replicas: 1
-      selector:
-        matchLabels:
-          app.kubernetes.io/instance: RELEASE-NAME
-          app.kubernetes.io/name: ara
-      strategy:
-        type: Recreate
-      template:
-        metadata:
-          labels:
-            app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/name: ara
-        spec:
-          containers:
-            - env:
-                - name: ARA_ALLOWED_HOSTS
-                  value: '["*"]'
-                - name: ARA_IGNORED_FACTS
-                  value: '["ansible_env_skip"]'
-              image: ghcr.io/azimuth-cloud/ara-api:main
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  httpHeaders:
-                    - name: Host
-                      value: localhost
-                  path: /api/v1/
-                  port: http
-              name: ara
-              ports:
-                - containerPort: 8000
-                  name: http
-                  protocol: TCP
-              readinessProbe:
-                httpGet:
-                  httpHeaders:
-                    - name: Host
-                      value: localhost
-                  path: /api/v1/
-                  port: http
-              resources: {}
-              securityContext:
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop:
-                    - ALL
-                readOnlyRootFilesystem: true
-              volumeMounts:
-                - mountPath: /opt/ara
-                  name: data
-                - mountPath: /tmp
-                  name: tmp
-          securityContext:
-            fsGroup: 1001
-            runAsGroup: 1001
-            runAsNonRoot: true
-            runAsUser: 1001
-          volumes:
-            - name: data
-              persistentVolumeClaim:
-                claimName: release-name-ara
-            - emptyDir: {}
-              name: tmp
-  2: |
-    apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      labels:
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: ara
-        app.kubernetes.io/version: main
-        helm.sh/chart: ara-0.1.0
-      name: release-name-ara
-    spec:
-      accessModes:
-        - ReadWriteOnce
-      resources:
-        requests:
-          storage: 8Gi
-  3: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      labels:
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: ara
-        app.kubernetes.io/version: main
-        helm.sh/chart: ara-0.1.0
-      name: release-name-ara
-    spec:
-      ports:
-        - name: http
-          port: 8000
-          protocol: TCP
-          targetPort: http
-      selector:
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/name: ara
-      type: ClusterIP
-  4: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -133,7 +20,7 @@ templated manifests should match snapshot:
           - '*'
         verbs:
           - '*'
-  5: |
+  2: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -150,7 +37,20 @@ templated manifests should match snapshot:
         resources:
           - customresourcedefinitions
         verbs:
-          - '*'
+          - list
+          - watch
+      - apiGroups:
+          - apiextensions.k8s.io
+        resourceNames:
+          - clusters.caas.azimuth.stackhpc.com
+          - clustertypes.caas.azimuth.stackhpc.com
+        resources:
+          - customresourcedefinitions
+        verbs:
+          - get
+          - create
+          - update
+          - patch
       - apiGroups:
           - ""
         resources:
@@ -225,7 +125,7 @@ templated manifests should match snapshot:
           - get
           - create
           - update
-  6: |
+  3: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -254,7 +154,7 @@ templated manifests should match snapshot:
           - get
           - create
           - update
-  7: |
+  4: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -275,7 +175,7 @@ templated manifests should match snapshot:
           - get
           - list
           - watch
-  8: |
+  5: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -294,7 +194,7 @@ templated manifests should match snapshot:
       - kind: ServiceAccount
         name: release-name-azimuth-caas-operator
         namespace: NAMESPACE
-  9: |
+  6: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -360,7 +260,7 @@ templated manifests should match snapshot:
           volumes:
             - emptyDir: {}
               name: tmp
-  10: |
+  7: |
     apiVersion: v1
     kind: Secret
     metadata:
@@ -374,7 +274,7 @@ templated manifests should match snapshot:
     stringData:
       extravars: |
         {}
-  11: |
+  8: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -395,7 +295,7 @@ templated manifests should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: azimuth-caas-operator
       type: ClusterIP
-  12: |
+  9: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:

--- a/charts/operator/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/operator/tests/__snapshot__/snapshot_test.yaml.snap
@@ -1,5 +1,118 @@
 templated manifests should match snapshot:
   1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: ara
+        app.kubernetes.io/version: main
+        helm.sh/chart: ara-0.1.0
+      name: release-name-ara
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: ara
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: ara
+        spec:
+          containers:
+            - env:
+                - name: ARA_ALLOWED_HOSTS
+                  value: '["*"]'
+                - name: ARA_IGNORED_FACTS
+                  value: '["ansible_env_skip"]'
+              image: ghcr.io/azimuth-cloud/ara-api:main
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  httpHeaders:
+                    - name: Host
+                      value: localhost
+                  path: /api/v1/
+                  port: http
+              name: ara
+              ports:
+                - containerPort: 8000
+                  name: http
+                  protocol: TCP
+              readinessProbe:
+                httpGet:
+                  httpHeaders:
+                    - name: Host
+                      value: localhost
+                  path: /api/v1/
+                  port: http
+              resources: {}
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - mountPath: /opt/ara
+                  name: data
+                - mountPath: /tmp
+                  name: tmp
+          securityContext:
+            fsGroup: 1001
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: release-name-ara
+            - emptyDir: {}
+              name: tmp
+  2: |
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: ara
+        app.kubernetes.io/version: main
+        helm.sh/chart: ara-0.1.0
+      name: release-name-ara
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 8Gi
+  3: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: ara
+        app.kubernetes.io/version: main
+        helm.sh/chart: ara-0.1.0
+      name: release-name-ara
+    spec:
+      ports:
+        - name: http
+          port: 8000
+          protocol: TCP
+          targetPort: http
+      selector:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: ara
+      type: ClusterIP
+  4: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -20,7 +133,7 @@ templated manifests should match snapshot:
           - '*'
         verbs:
           - '*'
-  2: |
+  5: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -125,7 +238,7 @@ templated manifests should match snapshot:
           - get
           - create
           - update
-  3: |
+  6: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -154,7 +267,7 @@ templated manifests should match snapshot:
           - get
           - create
           - update
-  4: |
+  7: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
@@ -175,7 +288,7 @@ templated manifests should match snapshot:
           - get
           - list
           - watch
-  5: |
+  8: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -194,7 +307,7 @@ templated manifests should match snapshot:
       - kind: ServiceAccount
         name: release-name-azimuth-caas-operator
         namespace: NAMESPACE
-  6: |
+  9: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -260,7 +373,7 @@ templated manifests should match snapshot:
           volumes:
             - emptyDir: {}
               name: tmp
-  7: |
+  10: |
     apiVersion: v1
     kind: Secret
     metadata:
@@ -274,7 +387,7 @@ templated manifests should match snapshot:
     stringData:
       extravars: |
         {}
-  8: |
+  11: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -295,7 +408,7 @@ templated manifests should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: azimuth-caas-operator
       type: ClusterIP
-  9: |
+  12: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,8 +1,9 @@
 # Complains about invalid maintainer URLs
 validate-maintainers: false
-# Skip version bump detection and lint all charts
-# since we're using the azimuth-cloud Helm chart publish
-# workflow which doesn't use Chart.yaml's version key
+# Skip version bump detection since we're using the azimuth-cloud Helm
+# chart publish workflow which overrides Chart.yaml's version key via CI
+check-version-increment: false
+# Lint all charts on every run, not only changed ones
 all: true
 # Split output to make it look nice in GitHub Actions tab
 github-groups: true

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,9 +1,8 @@
 # Complains about invalid maintainer URLs
 validate-maintainers: false
-# Skip version bump detection since we're using the azimuth-cloud Helm
-# chart publish workflow which overrides Chart.yaml's version key via CI
-check-version-increment: false
-# Lint all charts on every run, not only changed ones
+# Skip version bump detection and lint all charts
+# since we're using the azimuth-cloud Helm chart publish
+# workflow which doesn't use Chart.yaml's version key
 all: true
 # Split output to make it look nice in GitHub Actions tab
 github-groups: true


### PR DESCRIPTION
## Finding

ClusterRole grants wildcard verbs on `customresourcedefinitions`

## Root cause

The operator ClusterRole granted `["*"]` on all CRDs cluster-wide. A compromised operator could overwrite or delete CRDs belonging to other operators on the same cluster.

## Changes

- Split the CRD rule in two:
  - `list`, `watch` on all CRDs (required by kopf for CRD discovery — `resourceNames` cannot scope collection operations in Kubernetes RBAC)
  - `get`, `create`, `update`, `patch` restricted via `resourceNames` to the two CRDs this operator actually manages: `clusters.caas.azimuth.stackhpc.com` and `clustertypes.caas.azimuth.stackhpc.com`
- Updated helm-unittest snapshot accordingly (`helm unittest --update-snapshot`)